### PR TITLE
Remove py34 from support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'Topic :: Internet',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35,36}
+envlist = py{35,36}
 
 [testenv]
 deps =


### PR DESCRIPTION
No matching distribution found for sip>=4.19.1, required by pyqt5